### PR TITLE
Pagination + various bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,21 @@ A web API for managing a qremis "database".
 
 Run a dev server with the following command:
 ```bash
-QREMIS_API_CONFIG=$(pwd)/config.py sh debug.sh
+$ QREMIS_API_CONFIG=$(pwd)/config.py sh debug.sh
 ```
+
+The included config.py assumes you're running a redis instance listening on localhost on
+port 6379, and want to use db 0.
+
+If you have docker you can fire one of these up with
+```bash
+# docker run -p 6379:6379 redis
+```
+
+The included Dockerfile will build the application in a container, which means the
+container must have access to the redis instance referenced in the config.
+
+TODO: Whip up a docker-compose which includes both the redis instance and the
+application container in a single network.
 
 Author: balsamo@uchicago.edu

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ In development
 A web API for managing a qremis "database".
 
 Run a dev server with the following command:
-```bash
+```
 $ QREMIS_API_CONFIG=$(pwd)/config.py sh debug.sh
 ```
 
@@ -11,7 +11,7 @@ The included config.py assumes you're running a redis instance listening on loca
 port 6379, and want to use db 0.
 
 If you have docker you can fire one of these up with
-```bash
+```
 # docker run -p 6379:6379 redis
 ```
 

--- a/qremis_api/blueprint/__init__.py
+++ b/qremis_api/blueprint/__init__.py
@@ -188,6 +188,7 @@ class ObjectLinkedRelationships(Resource):
         if not record_exists("relationship", args['relationship_id']):
             raise ValueError("No such relationship identifier! ({})".format(args['relationship_id']))
         link_records("object", id, "relationship", args['relationship_id'])
+        return id
 
 
 class EventList(Resource):
@@ -265,6 +266,7 @@ class EventLinkedRelationships(Resource):
         if not record_exists("event", id) or not record_exists("relationship", args['relationship_id']):
             raise ValueError("Non-existant identifier!")
         link_records("event", id, "relationship", args['relationship_id'])
+        return id
 
 
 class AgentList(Resource):
@@ -360,6 +362,7 @@ class AgentLinkedRelationships(Resource):
         if not record_exists("agent", id) or not record_exists("relationship", args['relationship_id']):
             raise ValueError("Non-existant identifier!")
         link_records("agent", id, "relationship", args['relationship_id'])
+        return id
 
 
 class RightsList(Resource):
@@ -437,6 +440,7 @@ class RightsLinkedRelationships(Resource):
         if not record_exists("rights", id) or not record_exists("relationship", args['relationship_id']):
             raise ValueError("Non-existant identifier!")
         link_records("rights", id, "relationship", args['relationship_id'])
+        return id
 
 
 class RelationshipList(Resource):
@@ -567,6 +571,7 @@ class RelationshipLinkedObjects(Resource):
         if not record_exists("relationship", id) or not record_exists("object", args['object_id']):
             raise ValueError("Non-existant identifier!")
         link_records("relationship", id, "object", args['object_id'])
+        return id
 
 
 class RelationshipLinkedEvents(Resource):
@@ -591,6 +596,7 @@ class RelationshipLinkedEvents(Resource):
         if not record_exists("relationship", id) or not record_exists("event", args['event_id']):
             raise ValueError("Non-existant identifier!")
         link_records("relationship", id, "event", args['event_id'])
+        return id
 
 
 class RelationshipLinkedAgents(Resource):
@@ -615,6 +621,7 @@ class RelationshipLinkedAgents(Resource):
         if not record_exists("relationship", id) or not record_exists("agent", args['agent_id']):
             raise ValueError("Non-existant identifier!")
         link_records("relationship", id, "agent", args['agent_id'])
+        return id
 
 
 class RelationshipLinkedRights(Resource):
@@ -639,6 +646,7 @@ class RelationshipLinkedRights(Resource):
         if not record_exists("relationship", id) or not record_exists("rights", args['rights_id']):
             raise ValueError("Non-existant identifier!")
         link_records("relationship", id, "rights", args['rights_id'])
+        return id
 
 
 @BLUEPRINT.record

--- a/qremis_api/blueprint/__init__.py
+++ b/qremis_api/blueprint/__init__.py
@@ -46,14 +46,6 @@ def add_record(kind, id, rec):
 def link_records(kind1, id1, kind2, id2):
     kind3 = None
     id3 = None
-    # This puts kind of a lot of responsibility on the client to dissect the records
-    # before POSTing them and working with linking aftwards
-    # Eg, you can't just say "this is linked to a thing I'm going to add later"
-    # Instead you have to look back through your objects (that you've taken apart)
-    # in your app space saying "and now I will re-establish that object X participates in
-    # relationship Y"
-#    if not record_exists(kind1, id1) or not record_exists(kind2, id2):
-#        raise ValueError("A targeted record does not exist")
     if kind2 != "relationship":
         kind3 = kind2
         id3 = id2
@@ -69,6 +61,16 @@ def link_records(kind1, id1, kind2, id2):
             relationshipNote="Automatically created to facilitate linking"
         )
         add_record(kind2, id2, dumps(relationship_record.to_json()))
+    # This puts kind of a lot of responsibility on the client to dissect the records
+    # before POSTing them and working with linking aftwards
+    # Eg, you can't just say "this is linked to a thing I'm going to add later"
+    # Instead you have to look back through your objects (that you've taken apart)
+    # in your app space saying "and now I will re-establish that object X participates in
+    # relationship Y"
+    # if not record_exists(kind1, id1) or not record_exists(kind2, id2):
+    #     raise ValueError("A targeted record does not exist")
+    # if kind3 is not None and not record_exists(kind3, id3):
+    #     raise ValueError("A targeted record does not exist")
     BLUEPRINT.config['redis'].zadd(id1+"_"+kind2+"Links", 0, id2)
     BLUEPRINT.config['redis'].zadd(id2+"_"+kind1+"Links", 0, id1)
     if kind3 is not None and id3 is not None:
@@ -117,7 +119,8 @@ class ObjectList(Resource):
         r['starting_cursor'] = args['cursor']
         r['next_cursor'] = q[0] if q[0] != 0 else None
         r['limit'] = check_limit(args['limit'])
-        r['object_list'] = [{'id': x[0].decode('utf-8'), '_link': API.url_for(Object, id=x[0].decode('utf-8'))}
+        r['object_list'] = [{'id': x[0].decode('utf-8'),
+                             '_link': API.url_for(Object, id=x[0].decode('utf-8'))}
                             for x in q[1]]
         return r
 

--- a/qremis_api/blueprint/__init__.py
+++ b/qremis_api/blueprint/__init__.py
@@ -520,7 +520,7 @@ class Relationship(Resource):
             rec.add_linkingAgentIdentifier(
                 pyqremis.LinkingAgentIdentifier(
                     linkingAgentIdentifierType="uuid",
-                    linkingObjectIdentifierValue=x[0].decode("utf-8")
+                    linkingAgentIdentifierValue=x[0].decode("utf-8")
                 )
             )
 
@@ -623,7 +623,7 @@ class RelationshipLinkedRights(Resource):
         r['starting_cursor'] = args['cursor']
         r['next_cursor'] = q[0] if q[0] != 0 else None
         r['limit'] = check_limit(args['limit'])
-        r['linkingAgentIdentifier_list'] = [
+        r['linkingRightsIdentifier_list'] = [
             {'id': x[0].decode("utf-8"), '_link': API.url_for(Rights, id=x[0].decode("utf-8"))}
             for x in q[1]
         ]

--- a/qremis_api/blueprint/__init__.py
+++ b/qremis_api/blueprint/__init__.py
@@ -132,12 +132,18 @@ class ObjectList(Resource):
                 objId = x.get_objectIdentifierValue()
         if objId is None:
             raise RuntimeError()
-        for x in rec.get_linkingRelationshipIdentifier():
-            if x.get_linkingRelationshipIdentifierType() == "uuid":
-                link_records("object", objId, "relationship", x.get_linkingRelationshipIdentifierValue())
-        rec.del_linkingRelationshipIdentifier()
+        try:
+            for x in rec.get_linkingRelationshipIdentifier():
+                if x.get_linkingRelationshipIdentifierType() == "uuid":
+                    link_records("object", objId, "relationship", x.get_linkingRelationshipIdentifierValue())
+            rec.del_linkingRelationshipIdentifier()
+        except KeyError:
+            pass
         add_record("object", objId, dumps(rec.to_dict()))
-        return objId
+        r = {}
+        r['_link'] = API.url_for(Object, id=objId)
+        r['id'] = objId
+        return r
 
 
 class Object(Resource):
@@ -205,12 +211,18 @@ class EventList(Resource):
                 eventId = x.get_eventIdentifierValue()
         if eventId is None:
             raise RuntimeError()
-        for x in rec.get_linkingRelationshipIdentifier():
-            if x.get_linkingRelationshipIdentifierType() == "uuid":
-                link_records("event", eventId, "relationship", x.get_linkingRelationshipIdentifierValue())
-        rec.del_linkingRelationshipIdentifier()
+        try:
+            for x in rec.get_linkingRelationshipIdentifier():
+                if x.get_linkingRelationshipIdentifierType() == "uuid":
+                    link_records("event", eventId, "relationship", x.get_linkingRelationshipIdentifierValue())
+            rec.del_linkingRelationshipIdentifier()
+        except KeyError:
+            pass
         add_record("event", eventId, dumps(rec.to_dict()))
-        return eventId
+        r = {}
+        r['_link'] = API.url_for(Event, id=eventId)
+        r['id'] = eventId
+        return r
 
 
 class Event(Resource):
@@ -276,12 +288,18 @@ class AgentList(Resource):
                 agentId = x.get_agentIdentifierValue()
         if agentId is None:
             raise RuntimeError()
-        for x in rec.get_linkingRelationshipIdentifier():
-            if x.get_linkingRelationshipIdentifierType() == "uuid":
-                link_records("agent", agentId, "relationship", x.get_linkingRelationshipIdentifierValue())
-        rec.del_linkingRelationshipIdentifier()
+        try:
+            for x in rec.get_linkingRelationshipIdentifier():
+                if x.get_linkingRelationshipIdentifierType() == "uuid":
+                    link_records("agent", agentId, "relationship", x.get_linkingRelationshipIdentifierValue())
+            rec.del_linkingRelationshipIdentifier()
+        except KeyError:
+            pass
         add_record("agent", agentId, dumps(rec.to_dict()))
-        return agentId
+        r = {}
+        r['_link'] = API.url_for(Agent, id=agentId)
+        r['id'] = agentId
+        return r
 
 
 class Agent(Resource):
@@ -314,7 +332,7 @@ class Agent(Resource):
                 link_records("agent", agentId, "relationship", x.get_linkingRelationshipIdentifierValue())
         rec.del_linkingRelationshipIdentifier()
         add_record("agent", agentId, dumps(rec.to_dict()))
-        return agentId
+        return API.url_for(Agent, id=agentId)
 
 
 class AgentLinkedRelationships(Resource):
@@ -365,12 +383,18 @@ class RightsList(Resource):
                 rightsId = x.get_rightsIdentifierValue()
         if rightsId is None:
             raise RuntimeError()
-        for x in rec.get_linkingRelationshipIdentifier():
-            if x.get_linkingRelationshipIdentifierType() == "uuid":
-                link_records("rights", rightsId, "relationship", x.get_linkingRelationshipIdentifierValue())
-        rec.del_linkingRelationshipIdentifier()
+        try:
+            for x in rec.get_linkingRelationshipIdentifier():
+                if x.get_linkingRelationshipIdentifierType() == "uuid":
+                    link_records("rights", rightsId, "relationship", x.get_linkingRelationshipIdentifierValue())
+            rec.del_linkingRelationshipIdentifier()
+        except KeyError:
+            pass
         add_record("rights", rightsId, dumps(rec.to_dict()))
-        return rightsId
+        r = {}
+        r['_link'] = API.url_for(Rights, id=rightsId)
+        r['id'] = rightsId
+        return r
 
 
 class Rights(Resource):
@@ -439,28 +463,43 @@ class RelationshipList(Resource):
         if relationshipId is None:
             raise RuntimeError()
 
-        for x in rec.get_linkingObjectIdentifier():
-            if x.get_linkingObjectIdentifierType() == "uuid":
-                link_records("relationship", relationshipId, "object", x.get_linkingObjectIdentifierValue())
-        rec.del_linkingObjectIdenitifer()
+        try:
+            for x in rec.get_linkingObjectIdentifier():
+                if x.get_linkingObjectIdentifierType() == "uuid":
+                    link_records("relationship", relationshipId, "object", x.get_linkingObjectIdentifierValue())
+            rec.del_linkingObjectIdenitifer()
+        except KeyError:
+            pass
 
-        for x in rec.get_linkingEventIdentifier():
-            if x.get_linkingEventIdentifierType() == "uuid":
-                link_records("relationship", relationshipId, "event", x.get_linkingEventIdentifierValue())
-        rec.del_linkingEventIdenitifer()
+        try:
+            for x in rec.get_linkingEventIdentifier():
+                if x.get_linkingEventIdentifierType() == "uuid":
+                    link_records("relationship", relationshipId, "event", x.get_linkingEventIdentifierValue())
+            rec.del_linkingEventIdenitifer()
+        except KeyError:
+            pass
 
-        for x in rec.get_linkingAgentIdentifier():
-            if x.get_linkingAgentIdentifierType() == "uuid":
-                link_records("relationship", relationshipId, "agent", x.get_linkingAgentIdentifierValue())
-        rec.del_linkingAgentIdenitifer()
+        try:
+            for x in rec.get_linkingAgentIdentifier():
+                if x.get_linkingAgentIdentifierType() == "uuid":
+                    link_records("relationship", relationshipId, "agent", x.get_linkingAgentIdentifierValue())
+            rec.del_linkingAgentIdenitifer()
+        except KeyError:
+            pass
 
-        for x in rec.get_linkingRightsIdentifier():
-            if x.get_linkingRightsIdentifierType() == "uuid":
-                link_records("relationship", relationshipId, "rights", x.get_linkingRightsIdentifierValue())
-        rec.del_linkingRightsIdenitifer()
+        try:
+            for x in rec.get_linkingRightsIdentifier():
+                if x.get_linkingRightsIdentifierType() == "uuid":
+                    link_records("relationship", relationshipId, "rights", x.get_linkingRightsIdentifierValue())
+            rec.del_linkingRightsIdenitifer()
+        except KeyError:
+            pass
 
         add_record("relationship", relationshipId, dumps(rec.to_dict()))
-        return relationshipId
+        r = {}
+        r['_link'] = API.url_for(Relationship, id=relationshipId)
+        r['id'] = relationshipId
+        return r
 
 
 class Relationship(Resource):
@@ -637,6 +676,6 @@ API.add_resource(RightsLinkedRelationships, "/rights_list/<string:id>/linkedRela
 API.add_resource(RelationshipList, "/relationship_list")
 API.add_resource(Relationship, "/relationship_list/<string:id>")
 API.add_resource(RelationshipLinkedObjects, "/relationship_list/<string:id>/linkedObjects")
-API.add_resource(RelationshipLinkedEvents, "/relatiomship_list/<string:id>/linkedEvents")
+API.add_resource(RelationshipLinkedEvents, "/relationship_list/<string:id>/linkedEvents")
 API.add_resource(RelationshipLinkedAgents, "/relationship_list/<string:id>/linkedAgents")
 API.add_resource(RelationshipLinkedRights, "/relationship_list/<string:id>/linkedRights")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -6,6 +6,7 @@ from argparse import ArgumentParser
 
 from pyqremis import *
 
+# TODO: Change this from a hacky script to real unit tests
 
 def make_object():
     objIdentifier = ObjectIdentifier(objectIdentifierType="uuid", objectIdentifierValue=uuid4().hex)
@@ -92,37 +93,177 @@ def main():
         requests.get(args.api_root+simple_relationship_resp.json()['_link']).json() == relationship.to_dict()
     )
 
-    obj_link_resp = requests.get(args.api_root+simple_object_resp.json()['_link']+'/linkedRelationships')
-    obj_link_resp.raise_for_status()
-    obj_link_resp.json()
+    obj_links_resp = requests.get(args.api_root+simple_object_resp.json()['_link']+'/linkedRelationships')
+    obj_links_resp.raise_for_status()
+    obj_links_resp.json()
 
-    event_link_resp = requests.get(args.api_root+simple_event_resp.json()['_link']+'/linkedRelationships')
-    event_link_resp.raise_for_status()
-    event_link_resp.json()
+    event_links_resp = requests.get(args.api_root+simple_event_resp.json()['_link']+'/linkedRelationships')
+    event_links_resp.raise_for_status()
+    event_links_resp.json()
 
-    agent_link_resp = requests.get(args.api_root+simple_agent_resp.json()['_link']+'/linkedRelationships')
-    agent_link_resp.raise_for_status()
-    agent_link_resp.json()
+    agent_links_resp = requests.get(args.api_root+simple_agent_resp.json()['_link']+'/linkedRelationships')
+    agent_links_resp.raise_for_status()
+    agent_links_resp.json()
 
-    rights_link_resp = requests.get(args.api_root+simple_rights_resp.json()['_link']+'/linkedRelationships')
-    rights_link_resp.raise_for_status()
-    rights_link_resp.json()
+    rights_links_resp = requests.get(args.api_root+simple_rights_resp.json()['_link']+'/linkedRelationships')
+    rights_links_resp.raise_for_status()
+    rights_links_resp.json()
 
-    relationship_link_resp1 = requests.get(args.api_root+simple_relationship_resp.json()['_link']+'/linkedObjects')
-    relationship_link_resp1.raise_for_status()
-    relationship_link_resp1.json()
+    relationship_links_resp1 = requests.get(args.api_root+simple_relationship_resp.json()['_link']+'/linkedObjects')
+    relationship_links_resp1.raise_for_status()
+    relationship_links_resp1.json()
 
-    relationship_link_resp2 = requests.get(args.api_root+simple_relationship_resp.json()['_link']+'/linkedEvents')
-    relationship_link_resp2.raise_for_status()
-    relationship_link_resp2.json()
+    relationship_links_resp2 = requests.get(args.api_root+simple_relationship_resp.json()['_link']+'/linkedEvents')
+    relationship_links_resp2.raise_for_status()
+    relationship_links_resp2.json()
 
-    relationship_link_resp3 = requests.get(args.api_root+simple_relationship_resp.json()['_link']+'/linkedAgents')
-    relationship_link_resp3.raise_for_status()
-    relationship_link_resp3.json()
+    relationship_links_resp3 = requests.get(args.api_root+simple_relationship_resp.json()['_link']+'/linkedAgents')
+    relationship_links_resp3.raise_for_status()
+    relationship_links_resp3.json()
 
-    relationship_link_resp4 = requests.get(args.api_root+simple_relationship_resp.json()['_link']+'/linkedRights')
-    relationship_link_resp4.raise_for_status()
-    relationship_link_resp4.json()
+    relationship_links_resp4 = requests.get(args.api_root+simple_relationship_resp.json()['_link']+'/linkedRights')
+    relationship_links_resp4.raise_for_status()
+    relationship_links_resp4.json()
 
+    # TODO: Change these from prints to asserts
+    link_obj_resp = requests.post(
+        args.api_root+simple_object_resp.json()['_link']+'/linkedRelationships',
+        data={
+            "relationship_id": relationship.get_relationshipIdentifier()[0].get_relationshipIdentifierValue()
+        }
+    )
+    print("###############")
+    print(
+        dumps(
+            requests.get(
+                args.api_root+"/object_list" + "/" + obj.get_objectIdentifier()[0].get_objectIdentifierValue()
+            ).json(),
+            indent=4
+        )
+    )
+    print("###############")
+    print(
+        dumps(
+            requests.get(
+                args.api_root+"/relationship_list" + "/" + relationship.get_relationshipIdentifier()[0].get_relationshipIdentifierValue()
+            ).json(), indent=4
+        )
+    )
+
+    print("###############")
+    link_event_resp = requests.post(
+        args.api_root+simple_event_resp.json()['_link']+'/linkedRelationships',
+        data={
+            "relationship_id": relationship.get_relationshipIdentifier()[0].get_relationshipIdentifierValue()
+        }
+    )
+    print(
+        dumps(
+            requests.get(
+                args.api_root+"/event_list" + "/" + event.get_eventIdentifier()[0].get_eventIdentifierValue()
+            ).json(),
+            indent=4
+        )
+    )
+    print("###############")
+    print(
+        dumps(
+            requests.get(
+                args.api_root+"/relationship_list" + "/" + relationship.get_relationshipIdentifier()[0].get_relationshipIdentifierValue()
+            ).json(), indent=4
+        )
+    )
+
+    print("###############")
+    link_agent_resp = requests.post(
+        args.api_root+simple_agent_resp.json()['_link']+'/linkedRelationships',
+        data={
+            "relationship_id": relationship.get_relationshipIdentifier()[0].get_relationshipIdentifierValue()
+        }
+    )
+    print(
+        dumps(
+            requests.get(
+                args.api_root+"/agent_list" + "/" + agent.get_agentIdentifier()[0].get_agentIdentifierValue()
+            ).json(),
+            indent=4
+        )
+    )
+    print("###############")
+    print(
+        dumps(
+            requests.get(
+                args.api_root+"/relationship_list" + "/" + relationship.get_relationshipIdentifier()[0].get_relationshipIdentifierValue()
+            ).json(), indent=4
+        )
+    )
+
+    print("###############")
+    link_rights_resp = requests.post(
+        args.api_root+simple_rights_resp.json()['_link']+'/linkedRelationships',
+        data={
+            "relationship_id": relationship.get_relationshipIdentifier()[0].get_relationshipIdentifierValue()
+        }
+    )
+    print(
+        dumps(
+            requests.get(
+                args.api_root+"/rights_list" + "/" + rights.get_rightsIdentifier()[0].get_rightsIdentifierValue()
+            ).json(),
+            indent=4
+        )
+    )
+    print("###############")
+    print(
+        dumps(
+            requests.get(
+                args.api_root+"/relationship_list" + "/" + relationship.get_relationshipIdentifier()[0].get_relationshipIdentifierValue()
+            ).json(), indent=4
+        )
+    )
+
+    print("###############")
+    print(
+        dumps(
+            requests.get(
+                args.api_root+"/relationship_list" + "/" +
+                relationship.get_relationshipIdentifier()[0].get_relationshipIdentifierValue() +
+                "/linkedObjects").json(),
+            indent=4
+        )
+    )
+
+    print("###############")
+    print(
+        dumps(
+            requests.get(
+                args.api_root+"/relationship_list" + "/" +
+                relationship.get_relationshipIdentifier()[0].get_relationshipIdentifierValue() +
+                "/linkedEvents").json(),
+            indent=4
+        )
+    )
+
+    print("###############")
+    print(
+        dumps(
+            requests.get(
+                args.api_root+"/relationship_list" + "/" +
+                relationship.get_relationshipIdentifier()[0].get_relationshipIdentifierValue() +
+                "/linkedAgents").json(),
+            indent=4
+        )
+    )
+
+    print("###############")
+    print(
+        dumps(
+            requests.get(
+                args.api_root+"/relationship_list" + "/" +
+                relationship.get_relationshipIdentifier()[0].get_relationshipIdentifierValue() +
+                "/linkedRights").json(),
+            indent=4
+        )
+    )
 if __name__ == "__main__":
     main()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,0 +1,128 @@
+from uuid import uuid4
+from json import dumps
+import requests
+import datetime
+from argparse import ArgumentParser
+
+from pyqremis import *
+
+
+def make_object():
+    objIdentifier = ObjectIdentifier(objectIdentifierType="uuid", objectIdentifierValue=uuid4().hex)
+    objChar = ObjectCharacteristics(Format(FormatDesignation(formatName="foo")))
+    obj = Object(objIdentifier, objChar, objectCategory="file")
+    return obj
+
+
+def make_relationship():
+    relIdentifier = RelationshipIdentifier(
+        relationshipIdentifierType="uuid",
+        relationshipIdentifierValue=uuid4().hex
+    )
+    rel = Relationship(relIdentifier, relationshipType="link", relationshipSubType="simple")
+    return rel
+
+
+def make_agent():
+    agentIdentifier = AgentIdentifier(agentIdentifierType="uuid", agentIdentifierValue=uuid4().hex)
+    return Agent(agentIdentifier)
+
+
+def make_rights():
+    rightsIdentifier = RightsIdentifier(rightsIdentifierType="uuid", rightsIdentifierValue=uuid4().hex)
+    return Rights(rightsIdentifier)
+
+
+def make_event():
+    eventIdentifier = EventIdentifier(eventIdentifierType="uuid", eventIdentifierValue=uuid4().hex)
+    eventType = "testing"
+    eventDateTime = str(datetime.datetime.now())
+    return Event(eventIdentifier, eventType=eventType, eventDateTime=eventDateTime)
+
+
+def add_linkingRelationshipIdentifier(entity, rel_id):
+    entity.add_linkingRelationshipIdentifier(
+        LinkingRelationshipIdentifier(
+            linkingRelationshipIdentifierType="uuid",
+            linkingRelationshipIdentifierValue=rel_id
+        )
+    )
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("api_root", type=str)
+    args = parser.parse_args()
+    obj = make_object()
+    event = make_event()
+    agent = make_agent()
+    rights = make_rights()
+    relationship = make_relationship()
+    simple_object_resp = requests.post(args.api_root+"/object_list", data={'record': dumps(obj.to_dict())})
+    simple_event_resp = requests.post(args.api_root+"/event_list", data={'record': dumps(event.to_dict())})
+    simple_agent_resp = requests.post(args.api_root+"/agent_list", data={'record': dumps(agent.to_dict())})
+    simple_rights_resp = requests.post(args.api_root+"/rights_list", data={'record': dumps(rights.to_dict())})
+    simple_relationship_resp = requests.post(args.api_root+"/relationship_list", data={'record': dumps(relationship.to_dict())})
+
+    simple_responses = [simple_object_resp, simple_event_resp,
+                        simple_agent_resp, simple_rights_resp,
+                        simple_relationship_resp]
+
+    for x in simple_responses:
+        x.raise_for_status()
+        x.json()
+
+    assert(
+        requests.get(args.api_root+simple_object_resp.json()['_link']).json() == obj.to_dict()
+    )
+
+    assert(
+        requests.get(args.api_root+simple_agent_resp.json()['_link']).json() == agent.to_dict()
+    )
+
+    assert(
+        requests.get(args.api_root+simple_event_resp.json()['_link']).json() == event.to_dict()
+    )
+
+    assert(
+        requests.get(args.api_root+simple_rights_resp.json()['_link']).json() == rights.to_dict()
+    )
+
+    assert(
+        requests.get(args.api_root+simple_relationship_resp.json()['_link']).json() == relationship.to_dict()
+    )
+
+    obj_link_resp = requests.get(args.api_root+simple_object_resp.json()['_link']+'/linkedRelationships')
+    obj_link_resp.raise_for_status()
+    obj_link_resp.json()
+
+    event_link_resp = requests.get(args.api_root+simple_event_resp.json()['_link']+'/linkedRelationships')
+    event_link_resp.raise_for_status()
+    event_link_resp.json()
+
+    agent_link_resp = requests.get(args.api_root+simple_agent_resp.json()['_link']+'/linkedRelationships')
+    agent_link_resp.raise_for_status()
+    agent_link_resp.json()
+
+    rights_link_resp = requests.get(args.api_root+simple_rights_resp.json()['_link']+'/linkedRelationships')
+    rights_link_resp.raise_for_status()
+    rights_link_resp.json()
+
+    relationship_link_resp1 = requests.get(args.api_root+simple_relationship_resp.json()['_link']+'/linkedObjects')
+    relationship_link_resp1.raise_for_status()
+    relationship_link_resp1.json()
+
+    relationship_link_resp2 = requests.get(args.api_root+simple_relationship_resp.json()['_link']+'/linkedEvents')
+    relationship_link_resp2.raise_for_status()
+    relationship_link_resp2.json()
+
+    relationship_link_resp3 = requests.get(args.api_root+simple_relationship_resp.json()['_link']+'/linkedAgents')
+    relationship_link_resp3.raise_for_status()
+    relationship_link_resp3.json()
+
+    relationship_link_resp4 = requests.get(args.api_root+simple_relationship_resp.json()['_link']+'/linkedRights')
+    relationship_link_resp4.raise_for_status()
+    relationship_link_resp4.json()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces pagination to relevant endpoints (though still produces entity records **in their entirety no matter what**)

It also fixes several small bugs, mostly to do with mistyping things.

Additionally it fleshes out some of the endpoint return values into more REST-y looking responses.

For more work on endpoint return values (and arguments) see #1 

I imagine that will warrant a whole branch of its own, once more planning has taken place.